### PR TITLE
Change appropriate tags to hide and select/unselect components in group

### DIFF
--- a/resources/assets/js/cachet.js
+++ b/resources/assets/js/cachet.js
@@ -216,7 +216,9 @@ $(function () {
         $('input[name=remove_banner]').val('1');
     });
 
-    $('.group-name').on('click', function () {
+    $('.group-name').on('click', function (event) {
+        event.stopPropagation();
+
         var $this = $(this);
 
         $this.find('.group-toggle').toggleClass('ion-ios-minus-outline').toggleClass('ion-ios-plus-outline');
@@ -224,20 +226,16 @@ $(function () {
         $this.next('.group-items').toggleClass('hide');
     });
 
-    $('.select-group').on('click', function () {
+    $('.select-group').on('click', function (event) {
         var $parentGroup = $(this).closest('ul.list-group');
         $parentGroup.find('input[type=checkbox]').prop('checked', true);
-        $parentGroup.find('.group-items').removeClass('hide')
-        $parentGroup.find('.group-toggle').addClass('ion-ios-minus-outline').removeClass('ion-ios-plus-outline');
         event.stopPropagation();
         return false;
     });
 
-    $('.deselect-group').on('click', function () {
+    $('.deselect-group').on('click', function (event) {
         var $parentGroup = $(this).closest('ul.list-group');
         $parentGroup.find('input[type=checkbox]').prop('checked', false);
-        $parentGroup.find('.group-items').addClass('hide');
-        $parentGroup.find('.group-toggle').removeClass('ion-ios-minus-outline').addClass('ion-ios-plus-outline');
         event.stopPropagation();
         return false;
     });

--- a/resources/views/subscribe/manage.blade.php
+++ b/resources/views/subscribe/manage.blade.php
@@ -41,9 +41,14 @@
             @endforeach
 
             @if($ungroupedComponents->isNotEmpty())
-            <ul class="list-group components">
+            <ul class="list-group">
                 <div class="list-group-item group-name">
                     <strong>{{ trans('cachet.components.group.other') }}</strong>
+                    <div class="pull-right text-muted small">
+                        <a href="javascript: void(0);" class="select-group" id="select-all-{{$componentGroup->id}}">{{ trans('cachet.components.select_all') }}</a>
+                        &nbsp;|&nbsp;
+                        <a href="javascript: void(0);" class="deselect-group" id="deselect-all-{{$componentGroup->id}}">{{ trans('cachet.components.deselect_all') }}</a>
+                    </div>
                 </div>
                 @foreach($ungroupedComponents as $component)
                 @include('partials.component_input', compact($component))

--- a/resources/views/subscribe/manage.blade.php
+++ b/resources/views/subscribe/manage.blade.php
@@ -20,8 +20,7 @@
             <input type="hidden" name="_token" value="{{ csrf_token() }}">
             @if($componentGroups->isNotEmpty() || $ungroupedComponents->isNotEmpty())
             @foreach($componentGroups as $componentGroup)
-            <ul class="list-group components">
-                @if($componentGroup->enabled_components->count() > 0)
+            <ul class="list-group">
                     <li class="list-group-item group-name">
                         <i class="{{ $componentGroup->collapse_class_with_subscriptions($subscriptions) }} group-toggle"></i>
                         <strong>{{ $componentGroup->name }}</strong>

--- a/resources/views/subscribe/manage.blade.php
+++ b/resources/views/subscribe/manage.blade.php
@@ -20,22 +20,24 @@
             <input type="hidden" name="_token" value="{{ csrf_token() }}">
             @if($componentGroups->isNotEmpty() || $ungroupedComponents->isNotEmpty())
             @foreach($componentGroups as $componentGroup)
-            <div class="list-group components">
+            <ul class="list-group components">
                 @if($componentGroup->enabled_components->count() > 0)
-                <div class="list-group-item group-name">
-                    <i class="{{ $componentGroup->collapse_class_with_subscriptions($subscriptions) }} group-toggle"></i>
-                    <strong>{{ $componentGroup->name }}</strong>
-                    <div class="pull-right text-muted small">
-                        <a href="javascript: void(0);" class="select-group" id="select-all-{{$componentGroup->id}}">{{ trans('cachet.components.select_all') }}</a>
-                        &nbsp;|&nbsp;
-                        <a href="javascript: void(0);" class="deselect-group" id="deselect-all-{{$componentGroup->id}}">{{ trans('cachet.components.deselect_all') }}</a>
+                    <li class="list-group-item group-name">
+                        <i class="{{ $componentGroup->collapse_class_with_subscriptions($subscriptions) }} group-toggle"></i>
+                        <strong>{{ $componentGroup->name }}</strong>
+                        <div class="pull-right text-muted small">
+                            <a href="javascript: void(0);" class="select-group" id="select-all-{{$componentGroup->id}}">{{ trans('cachet.components.select_all') }}</a>
+                            &nbsp;|&nbsp;
+                            <a href="javascript: void(0);" class="deselect-group" id="deselect-all-{{$componentGroup->id}}">{{ trans('cachet.components.deselect_all') }}</a>
+                        </div>
+                    </li>
+                    <div class="form-group group-items {{ $componentGroup->has_subscriber($subscriptions) ? null : "hide" }}">
+                        @foreach($componentGroup->enabled_components()->orderBy('order')->get() as $component)
+                        @include('partials.component_input', compact($component))
+                        @endforeach
                     </div>
-                </div>
-                @foreach($componentGroup->enabled_components()->orderBy('order')->get() as $component)
-                @include('partials.component_input', compact($component))
-                @endforeach
                 @endif
-            </div>
+            </ul>
             @endforeach
 
             @if($ungroupedComponents->isNotEmpty())

--- a/resources/views/subscribe/manage.blade.php
+++ b/resources/views/subscribe/manage.blade.php
@@ -21,6 +21,7 @@
             @if($componentGroups->isNotEmpty() || $ungroupedComponents->isNotEmpty())
             @foreach($componentGroups as $componentGroup)
             <ul class="list-group">
+                @if($componentGroup->enabled_components()->count() > 0)
                     <li class="list-group-item group-name">
                         <i class="{{ $componentGroup->collapse_class_with_subscriptions($subscriptions) }} group-toggle"></i>
                         <strong>{{ $componentGroup->name }}</strong>


### PR DESCRIPTION
On clicking `Select All` or `Deselect All` checkboxes were not getting selected/deselected. On clicking `Group name` components were not getting collapsed/uncollapsed. This change adds correct tags and hides/unhide the components on clicking group name